### PR TITLE
Laravel 9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
         "php": "^7.4|^8.0",
         "ext-json": "*",
         "league/oauth2-client": "^2.6",
-        "illuminate/support": "^8.17",
-        "illuminate/http": "^8.17",
+        "illuminate/support": "^8.17|^9.0",
+        "illuminate/http": "^8.17|^9.0",
         "spatie/data-transfer-object": "^2.6"
     },
     "autoload": {


### PR DESCRIPTION
Could you please allow version 9 for `illuminate/support` and `illuminate/http` so that this package can also be used in combination with Laravel 9?