### PR TITLE
Laravel 10.x Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,11 @@
     "license": "BSD-3-Clause",
     "description": "Official PHP Pingen SDK for API V2",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "league/oauth2-client": "^2.6",
-        "illuminate/support": "^8.17|^9.0",
-        "illuminate/http": "^8.17|^9.0",
+        "illuminate/support": "^9.0 || ^10.0",
+        "illuminate/http": "^9.0 || ^10.0",
         "spatie/data-transfer-object": "^2.6"
     },
     "autoload": {


### PR DESCRIPTION
Updated for Laravel 10 support.
Please also update `spatie/data-transfer-object` dependency which is quite outdated.