### PR TITLE
Add support for laravel 11 and remove PHP 8.0 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.0', '8.1', '8.2', '8.3']
+        php: ['8.2', '8.3']
         stability: [prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.0', '8.1', '8.2']
+        php: ['8.0', '8.1', '8.2', '8.3']
         stability: [prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.2', '8.3']
+        php: ['8.1', '8.2', '8.3']
         stability: [prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "BSD-3-Clause",
     "description": "Official PHP Pingen SDK for API V2",
     "require": {
-        "php": "^8.2|^8.3",
+        "php": "^8.1|^8.2|^8.3",
         "ext-json": "*",
         "league/oauth2-client": "^2.6",
         "illuminate/support": "^10.0|^11.0",

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,11 @@
     "license": "BSD-3-Clause",
     "description": "Official PHP Pingen SDK for API V2",
     "require": {
-        "php": "^8.0|^8.1|^8.2|^8.3",
+        "php": "^8.2|^8.3",
         "ext-json": "*",
         "league/oauth2-client": "^2.6",
-        "illuminate/support": "^9.0|^10.0|^11.0",
-        "illuminate/http": "^9.0|^10.0|^11.0"
+        "illuminate/support": "^10.0|^11.0",
+        "illuminate/http": "^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,11 @@
     "license": "BSD-3-Clause",
     "description": "Official PHP Pingen SDK for API V2",
     "require": {
-        "php": "^8.0|^8.1|^8.2",
+        "php": "^8.0|^8.1|^8.2|^8.3",
         "ext-json": "*",
         "league/oauth2-client": "^2.6",
-        "illuminate/support": "^9.0|^10.0",
-        "illuminate/http": "^9.0|^10.0"
+        "illuminate/support": "^9.0|^10.0|^11.0",
+        "illuminate/http": "^9.0|^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {
@@ -29,7 +29,7 @@
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "^1.2",
         "nikic/php-parser": "4.15.*",
-        "phpunit/phpunit": "^9.3",
+        "phpunit/phpunit": "^10.5|^11.0",
         "mockery/mockery": "^1.4",
         "symplify/easy-coding-standard-prefixed": "9.2.6",
         "rector/rector": "^0.12.16",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          cacheResultFile=".phpunit.cache/test-results"
          executionOrder="depends,defects"
-         forceCoversAnnotation="false"
-         beStrictAboutCoversAnnotation="true"
+         requireCoverageMetadata="false"
+         beStrictAboutCoverageMetadata="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
          failOnRisky="true"
          failOnWarning="true"
-         verbose="true">
+         displayDetailsOnIncompleteTests="true"
+         displayDetailsOnSkippedTests="true">
     <testsuites>
         <testsuite name="default">
             <directory suffix="Test.php">tests</directory>
         </testsuite>
     </testsuites>
-    <coverage processUncoveredFiles="true">
+    <coverage>
+        <report>
+            <!-- <clover outputFile="coverage/clover.xml"/>-->
+            <html outputDirectory="coverage/html" lowUpperBound="50" highLowerBound="90"/>
+            <text outputFile="coverage/text" showUncoveredFiles="false" showOnlySummary="true"/>
+        </report>
+    </coverage>
+    <source>
         <include>
             <directory suffix=".php">./src/</directory>
             <directory suffix=".php">./tests/</directory>
@@ -24,10 +32,5 @@
         <exclude>
             <file>./src/run.php</file>
         </exclude>
-        <report>
-            <!-- <clover outputFile="coverage/clover.xml"/>-->
-            <html outputDirectory="coverage/html" lowUpperBound="50" highLowerBound="90"/>
-            <text outputFile="coverage/text" showUncoveredFiles="false" showOnlySummary="true"/>
-        </report>
-    </coverage>
+    </source>
 </phpunit>

--- a/tests/Endpoints/BatchEndpointTest.php
+++ b/tests/Endpoints/BatchEndpointTest.php
@@ -27,7 +27,7 @@ use Pingen\Exceptions\JsonApiExceptionError;
 use Pingen\Exceptions\JsonApiExceptionErrorSource;
 use Pingen\Exceptions\ValidationException;
 
-class BatchEndpointTest extends EndpointTest
+class BatchEndpointTest extends EndpointTestBase
 {
     public function testGetBatchCollection(): void
     {

--- a/tests/Endpoints/BatchEventsEndpointTest.php
+++ b/tests/Endpoints/BatchEventsEndpointTest.php
@@ -9,7 +9,7 @@ use Illuminate\Http\Response;
 use Pingen\Endpoints\BatchEventsEndpoint;
 use Pingen\Endpoints\ParameterBags\BatchEventCollectionParameterBag;
 
-class BatchEventsEndpointTest extends EndpointTest
+class BatchEventsEndpointTest extends EndpointTestBase
 {
     public function testGetCollection(): void
     {

--- a/tests/Endpoints/EndpointTestBase.php
+++ b/tests/Endpoints/EndpointTestBase.php
@@ -8,10 +8,10 @@ use League\OAuth2\Client\Token\AccessToken;
 use Tests\TestCase;
 
 /**
- * Class EndpointTest
+ * Class EndpointTestBase
  * @package Tests\Endpoints
  */
-abstract class EndpointTest extends TestCase
+abstract class EndpointTestBase extends TestCase
 {
     protected function getAccessToken(): AccessToken
     {

--- a/tests/Endpoints/FileUploadTest.php
+++ b/tests/Endpoints/FileUploadTest.php
@@ -13,7 +13,7 @@ use Pingen\Endpoints\DataTransferObjects\FileUpload\FileUploadDetailsData;
 use Pingen\Endpoints\FileUploadEndpoint;
 use Pingen\Endpoints\ParameterBags\FileUploadParameterBag;
 
-class FileUploadTest extends EndpointTest
+class FileUploadTest extends EndpointTestBase
 {
     public function testRequestFileUpload(): void
     {

--- a/tests/Endpoints/LetterEndpointTest.php
+++ b/tests/Endpoints/LetterEndpointTest.php
@@ -30,7 +30,7 @@ use Pingen\Exceptions\JsonApiExceptionErrorSource;
 use Pingen\Exceptions\RateLimitJsonApiException;
 use Pingen\Exceptions\ValidationException;
 
-class LetterEndpointTest extends EndpointTest
+class LetterEndpointTest extends EndpointTestBase
 {
     public function testGetLetterCollection(): void
     {

--- a/tests/Endpoints/LetterEventsEndpointTest.php
+++ b/tests/Endpoints/LetterEventsEndpointTest.php
@@ -13,7 +13,7 @@ use Pingen\Endpoints\ParameterBags\LetterEventCollectionParameterBag;
  * Class LetterEventsEndpointTest
  * @package Tests
  */
-class LetterEventsEndpointTest extends EndpointTest
+class LetterEventsEndpointTest extends EndpointTestBase
 {
     public function testGetCollection(): void
     {

--- a/tests/Endpoints/LetterIssuesEndpointTest.php
+++ b/tests/Endpoints/LetterIssuesEndpointTest.php
@@ -13,7 +13,7 @@ use Pingen\Endpoints\ParameterBags\LetterIssuesCollectionParameterBag;
  * Class LetterIssuesEndpointTest
  * @package Tests
  */
-class LetterIssuesEndpointTest extends EndpointTest
+class LetterIssuesEndpointTest extends EndpointTestBase
 {
     public function testGetCollection(): void
     {

--- a/tests/Endpoints/OrganisationsEndpointTest.php
+++ b/tests/Endpoints/OrganisationsEndpointTest.php
@@ -8,7 +8,7 @@ use Pingen\Endpoints\DataTransferObjects\Organisation\OrganisationAttributes;
 use Pingen\Endpoints\OrganisationsEndpoint;
 use Pingen\Endpoints\ParameterBags\OrganisationParameterBag;
 
-class OrganisationsEndpointTest extends EndpointTest
+class OrganisationsEndpointTest extends EndpointTestBase
 {
     public function testGetDetails(): void
     {

--- a/tests/Endpoints/UserAssociationsEndpointTest.php
+++ b/tests/Endpoints/UserAssociationsEndpointTest.php
@@ -19,7 +19,7 @@ use Pingen\Endpoints\UserAssociationsEndpoint;
 use Pingen\Exceptions\JsonApiExceptionError;
 use Pingen\Exceptions\JsonApiExceptionErrorSource;
 
-class UserAssociationsEndpointTest extends EndpointTest
+class UserAssociationsEndpointTest extends EndpointTestBase
 {
     public function testGetCollection(): void
     {

--- a/tests/Endpoints/UserEndpointTest.php
+++ b/tests/Endpoints/UserEndpointTest.php
@@ -8,7 +8,7 @@ use Pingen\Endpoints\DataTransferObjects\User\UserAttributes;
 use Pingen\Endpoints\ParameterBags\UserParameterBag;
 use Pingen\Endpoints\UserEndpoint;
 
-class UserEndpointTest extends EndpointTest
+class UserEndpointTest extends EndpointTestBase
 {
     public function testGetDetails(): void
     {

--- a/tests/Endpoints/WebhookEndpointTest.php
+++ b/tests/Endpoints/WebhookEndpointTest.php
@@ -15,7 +15,7 @@ use Pingen\Endpoints\WebhooksEndpoint;
 use Pingen\Exceptions\JsonApiExceptionError;
 use Pingen\Exceptions\JsonApiExceptionErrorSource;
 
-class WebhookEndpointTest extends EndpointTest
+class WebhookEndpointTest extends EndpointTestBase
 {
     public function testGetWebhookCollection(): void
     {

--- a/tests/Support/DataTransferObject/ArrTest.php
+++ b/tests/Support/DataTransferObject/ArrTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Support\DataTransferObject;
 
-use Illuminate\Support\Carbon;
+use Carbon\CarbonImmutable;
 use Pingen\Endpoints\DataTransferObjects\Letter\LetterAttributes;
 use Pingen\Support\DataTransferObject\DataTransferObject;
 use Tests\TestCase;
@@ -31,8 +31,8 @@ class ArrTest extends TestCase
                 'is_embedded' => true
             ]],
             'tracking_number' => '98.1234.11',
-            'created_at' => Carbon::make('2020-11-19T09:42:48+0100'),
-            'updated_at' => Carbon::make('2020-11-19T09:42:48+0100')
+            'created_at' => CarbonImmutable::make('2020-11-19T09:42:48+0100'),
+            'updated_at' => CarbonImmutable::make('2020-11-19T09:42:48+0100')
         ];
 
         $letterDTO = new LetterAttributes($expectedArray);


### PR DESCRIPTION
Add support for Illuminate/support and Illuminate/http 11.X

close [23](https://github.com/pingencom/pingen2-sdk-php/issues/23)