### PR TITLE
explicit nullable types

### DIFF
--- a/src/ResourceEndpoint.php
+++ b/src/ResourceEndpoint.php
@@ -218,11 +218,11 @@ abstract class ResourceEndpoint
      * @param string $endpoint
      * @param string $type
      * @param string $id
-     * @param Input $body
+     * @param Input|null $body
      * @return Response
      * @throws JsonApiException
      */
-    protected function performPatchRequest(string $endpoint, string $type, string $id, Input $body = null)
+    protected function performPatchRequest(string $endpoint, string $type, string $id, ?Input $body = null): Response
     {
         $data = [];
 


### PR DESCRIPTION
Fix PHP 8.4 deprecation of implicit nullable types:

```
Pingen\ResourceEndpoint::performPatchRequest(): Implicitly marking parameter $body as nullable is deprecated, the explicit nullable type must be used instead in vendor/pingencom/pingen2-sdk-php/src/ResourceEndpoint.php on line 225
```