### PR TITLE
Fix BatchSendAttributes DeliveryProducts naming

### DIFF
--- a/src/Endpoints/DataTransferObjects/Batch/BatchSendAttributes.php
+++ b/src/Endpoints/DataTransferObjects/Batch/BatchSendAttributes.php
@@ -7,13 +7,13 @@ namespace Pingen\Endpoints\DataTransferObjects\Batch;
 use Pingen\Support\Input;
 
 /**
- * @method BatchSendAttributes setDeliveryProduct(array $value)
+ * @method BatchSendAttributes setDeliveryProducts(array $value)
  * @method BatchSendAttributes setPrintMode(string $value)
  * @method BatchSendAttributes setPrintSpectrum(string $value)
  */
 class BatchSendAttributes extends Input
 {
-    protected array $delivery_product;
+    protected array $delivery_products;
 
     protected string $print_mode;
 


### PR DESCRIPTION
It looks like the naming of the delivery_product argument has been renamed to delivery_products.

I don't see a version history or changelog for the API, so I don't know if other fields have also been renamed between the last update of this SDK and the current API version.