### PR TITLE
Use hash_equals() for timing attack safe signature comparison in `IncomingWebhook`

### DIFF
--- a/src/IncomingWebhook/IncomingWebhook.php
+++ b/src/IncomingWebhook/IncomingWebhook.php
@@ -40,13 +40,15 @@ class IncomingWebhook
             throw new WebhookSignatureException('Only POST requests are allowed.');
         }
 
-        if (! $request->hasHeader('Signature')) {
+        $signature = $request->header('Signature');
+
+        if (! is_string($signature)) {
             throw new WebhookSignatureException('Signature missing.');
         }
 
         if (! hash_equals(
             hash_hmac('sha256', (string) $request->getContent(), $this->secret),
-            (string) $request->header('Signature')
+            $signature
         )) {
             throw new WebhookSignatureException('Webhook signature matching failed.');
         }

--- a/src/IncomingWebhook/IncomingWebhook.php
+++ b/src/IncomingWebhook/IncomingWebhook.php
@@ -46,7 +46,7 @@ class IncomingWebhook
 
         if (! hash_equals(
             hash_hmac('sha256', (string) $request->getContent(), $this->secret),
-            $request->header('Signature')
+            (string) $request->header('Signature')
         )) {
             throw new WebhookSignatureException('Webhook signature matching failed.');
         }

--- a/src/IncomingWebhook/IncomingWebhook.php
+++ b/src/IncomingWebhook/IncomingWebhook.php
@@ -44,7 +44,10 @@ class IncomingWebhook
             throw new WebhookSignatureException('Signature missing.');
         }
 
-        if ($request->header('Signature') !== hash_hmac('sha256', (string) $request->getContent(), $this->secret)) {
+        if (! hash_equals(
+            hash_hmac('sha256', (string) $request->getContent(), $this->secret),
+            $request->header('Signature')
+        )) {
             throw new WebhookSignatureException('Webhook signature matching failed.');
         }
     }


### PR DESCRIPTION
For timing attack safe signature hash comparison, we should always use `hash_equals()`, even on fixed length hashes.