### PR TITLE
Accept `AccessTokenInterface` on resource endpoints to fix PHPStan issues

### DIFF
--- a/src/ResourceEndpoint.php
+++ b/src/ResourceEndpoint.php
@@ -8,7 +8,7 @@ use Carbon\CarbonImmutable;
 use Illuminate\Http\Client\Factory as HttpClient;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
-use League\OAuth2\Client\Token\AccessToken;
+use League\OAuth2\Client\Token\AccessTokenInterface;
 use Pingen\Exceptions\JsonApiException;
 use Pingen\Exceptions\RateLimitJsonApiException;
 use Pingen\Support\CollectionParameterBag;
@@ -27,7 +27,7 @@ abstract class ResourceEndpoint
      */
     public const DEFAULT_REQUEST_TIMEOUT = 20;
 
-    protected AccessToken $accessToken;
+    protected AccessTokenInterface $accessToken;
 
     protected HttpClient $httpClient;
 
@@ -41,9 +41,9 @@ abstract class ResourceEndpoint
 
     /**
      * Endpoint constructor.
-     * @param AccessToken $accessToken
+     * @param AccessTokenInterface $accessToken
      */
-    public function __construct(AccessToken $accessToken)
+    public function __construct(AccessTokenInterface $accessToken)
     {
         $this->setAccessToken($accessToken);
         $this->setHttpClient(new HttpClient());
@@ -79,19 +79,19 @@ abstract class ResourceEndpoint
     }
 
     /**
-     * @param AccessToken $accessToken
+     * @param AccessTokenInterface $accessToken
      * @return ResourceEndpoint
      */
-    public function setAccessToken(AccessToken $accessToken): self
+    public function setAccessToken(AccessTokenInterface $accessToken): self
     {
         $this->accessToken = $accessToken;
         return $this;
     }
 
     /**
-     * @return AccessToken
+     * @return AccessTokenInterface
      */
-    public function getAccessToken(): AccessToken
+    public function getAccessToken(): AccessTokenInterface
     {
         return $this->accessToken;
     }


### PR DESCRIPTION
When retrieving the OAuth2 access token from `Pingen::getAccessToken()` (`Pingen extends \League\OAuth2\Client\Provider\AbstractProvider`), league/oauth2-client only guarantees a `AccessTokenInterface`, even though that's (currently) the `League\OAuth2\Client\Token\AuthToken` implementation.

The [docs](https://www.pingen.ch/en/post-api/) recommend this usage:

```php
$access_token = $provider->getAccessToken('client_credentials');

$lettersEndpoint = (new \Pingen\Endpoints\LettersEndpoint($access_token))
    ->setOrganisationId('INSERT_YOUR_ORGANISATION_UUID_HERE');
```

but that leads to a type mismatch and PHPStan (already at `level: 5`) complains about it:

```
Parameter #1 $accessToken of class Pingen\Endpoints\LettersEndpoint constructor expects League\OAuth2\Client\Token\AccessToken, League\OAuth2\Client\Token\AccessTokenInterface given.        
🪪  argument.type                                                                                                                                                                             
```